### PR TITLE
Fix AttributeError: module 'pyscf.pbc.df.ft_ao' has no attribute '_ft_aopair_kpts'

### DIFF
--- a/mpi4pyscf/pbc/df/df.py
+++ b/mpi4pyscf/pbc/df/df.py
@@ -310,7 +310,7 @@ def _make_j3c(mydf, cell, auxcell, kptij_lst, cderi_file):
             kLI = Gaux.imag.copy('C')
             Gaux = None
 
-            dat = ft_ao._ft_aopair_kpts(cell, Gv[p0:p1], shls_slice, aosym, b,
+            dat = ft_ao.ft_aopair_kpts(cell, Gv[p0:p1], shls_slice, aosym, b,
                                         gxyz[p0:p1], Gvbase, kpt,
                                         adapted_kptjs, out=buf)
             nG = p1 - p0

--- a/mpi4pyscf/pbc/df/mdf.py
+++ b/mpi4pyscf/pbc/df/mdf.py
@@ -248,7 +248,7 @@ def _make_j3c(mydf, cell, auxcell, kptij_lst, cderi_file):
         else:
             shls_slice = (sh0, sh1, 0, cell.nbas)
         for p0, p1 in lib.prange(0, ngrids, Gblksize):
-            dat = ft_ao._ft_aopair_kpts(cell, Gv[p0:p1], shls_slice, aosym, b,
+            dat = ft_ao.ft_aopair_kpts(cell, Gv[p0:p1], shls_slice, aosym, b,
                                         gxyz[p0:p1], Gvbase, kpt,
                                         adapted_kptjs, out=buf)
             nG = p1 - p0


### PR DESCRIPTION
This fixes issue #19 and is necessary because of [this commit ](https://github.com/pyscf/pyscf/commit/90fe896504e69490d662425d89768dd2fd882973#diff-eb0624d8f70ec044bea2222a0c71f12d503c1e6a792171c5476faff8c8433905L51) to PySCF.